### PR TITLE
install plugin

### DIFF
--- a/help/driving/ug/install-and-configure-support-package-for-customizing-scenes_zh_CN.html
+++ b/help/driving/ug/install-and-configure-support-package-for-customizing-scenes_zh_CN.html
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE html>
+
+<html xmlns="http://www.w3.org/1999/xhtml" itemscope="" itemtype="http://www.mathworks.com/help/schema/MathWorksDocPage">
+<head>
+<meta xmlns="http://www.w3.org/1999/xhtml" charset="utf-8"/>
+<meta xmlns="http://www.w3.org/1999/xhtml" name="viewport" content="width=device-width, initial-scale=1.0"/>
+<meta xmlns="http://www.w3.org/1999/xhtml" http-equiv="X-UA-Compatible" content="IE=edge"/>
+<title>Install Support Package for Customizing Scenes</title>
+<script xmlns="http://www.w3.org/1999/xhtml" type="application/ld+json">
+      {
+      "@context": "http://schema.org",
+      "@type": "BreadcrumbList",
+      "itemListElement":
+      [{
+          "@type": "ListItem",
+          "position": 1,
+
+          "item": {
+          "@id": "../index.html",
+          "name": "Automated Driving Toolbox"
+}
+
+          } 
+        ,
+        {
+          "@type": "ListItem",
+          "position": 2,
+
+          "item": {
+          "@id": "../scenario-simulation.html",
+          "name": "Scenario Simulation"
+}
+
+          }
+        ,
+        {
+          "@type": "ListItem",
+          "position": 3,
+
+          "item": {
+          "@id": "../unreal-engine-scenario-simulation.html",
+          "name": "Unreal Engine Scenario Simulation"
+}
+
+          }]
+      }</script>
+<script xmlns="http://www.w3.org/1999/xhtml" type="application/ld+json">
+        {
+        "@context": "http://schema.org",
+        "@type": "ItemList",
+          "name": "VisibleBreadcrumbs",
+
+        "itemListElement":
+        [
+        "unreal-engine-scenario-simulation"
+        ],
+        "itemListOrder": "http://schema.org/ItemListOrderAscending"
+        }
+        </script>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/bootstrap.min.css" rel="stylesheet" type="text/css"/>
+
+
+  <meta xmlns="http://www.w3.org/1999/xhtml" http-equiv="Content-Script-Type" content="text/javascript"/>
+<meta xmlns="http://www.w3.org/1999/xhtml" name="toctype" itemprop="pagetype" content="ug"/>
+<meta xmlns="http://www.w3.org/1999/xhtml" name="infotype" itemprop="infotype" content="ex"/>
+
+<meta xmlns="http://www.w3.org/1999/xhtml" name="description" itemprop="description" content="To customize scenes in the Unreal Editor, you must install and configure the Automated Driving Toolbox Interface for Unreal Engine 4 Projects."/>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/jquery/jquery-latest.js"></script>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6.css" rel="stylesheet" type="text/css"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_lg.css" rel="stylesheet" media="screen and (min-width: 1200px)"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_md.css" rel="stylesheet" media="screen and (min-width: 992px) and (max-width: 1199px)"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_sm+xs.css" rel="stylesheet" media="screen and (max-width: 991px)"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_sm.css" rel="stylesheet" media="screen and (min-width: 768px) and (max-width: 991px)"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_xs.css" rel="stylesheet" media="screen and (max-width: 767px)"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/site6_offcanvas_v2.css" rel="stylesheet" type="text/css"/>
+
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/l10n.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/docscripts.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/f1help.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/docscripts.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/mw.imageanimation.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/jquery.highlight.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/underscore-min.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/use_platform_screenshots.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/suggest.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/overload.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/helpservices.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/productfilter.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/product_group.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/scripts/saxonjs/SaxonJS2.rt.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml">
+            window.history.replaceState(window.location.href, null, ""); // Initialize
+            window.onload = function() {    
+            mystylesheetLocation = "../../includes/shared/scripts/product_group-sef.json";
+            mysourceLocation = "../../docset.xml";
+            product_help_location = "driving";
+            pagetype = "section";
+            doccentertype = "product";
+            langcode = "";
+            getProductFilteredList(mystylesheetLocation, mysourceLocation, product_help_location, pagetype, doccentertype, langcode);  
+            }
+          </script>
+
+
+
+
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/jquery/jquery.mobile.custom.min.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/bootstrap.min.js"></script>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/product/scripts/global.js"></script>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/doc_center_base.css" rel="stylesheet" type="text/css"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/doc_center_installed.css" rel="stylesheet" type="text/css"/>
+<link xmlns="http://www.w3.org/1999/xhtml" href="../../includes/product/css/doc_center_print.css" rel="stylesheet" type="text/css" media="print"/>
+<script xmlns="http://www.w3.org/1999/xhtml" src="../../includes/shared/equationrenderer/release/MathRenderer.js"></script>
+</head>
+<body id="responsive_offcanvas">
+<div xmlns="http://www.w3.org/1999/xhtml" id="doc_header_spacer" class="header"></div>
+<div xmlns="http://www.w3.org/1999/xhtml" class="section_header level_3"><div class="container-fluid"><div class="row" id="mobile_search_row"><div class="col-sm-6 col-md-7 has_horizontal_local_nav" id="section_header_title"><div class="section_header_content"><div class="section_header_title"><h1><a href="../../documentation-center.html">Help Center</a></h1>
+</div>
+</div>
+</div>
+<div class="col-xs-12 col-sm-6 col-md-5" id="mobile_search"><div class="search_nested_content_container"><form id="docsearch_form" name="docsearch_form" method="get" data-release="R2022b" data-language="en" action="../../templates/searchresults.html"><div class="input-group tokenized_search_field"><label class="sr-only">Search Help</label><input type="text" class="form-control conjoined_search" autocomplete="off" name="qdoc" placeholder="Search Help" id="docsearch"/> <div class="input-group-btn"><button type="submit" name="submitsearch" id="submitsearch" class="btn icon-search btn_search_adjacent btn_search icon_16" tabindex="-1"></button></div>
+</div></form>
+</div>
+<button class="btn icon-remove btn_search pull-right icon_32 visible-xs" data-toggle="collapse" href="#mobile_search" aria-expanded="false" aria-controls="mobile_search"></button></div>
+<div class="visible-xs" id="search_actuator"><button class="btn icon-search btn_search pull-right icon_16" data-toggle="collapse" href="#mobile_search" aria-expanded="false" aria-controls="mobile_search"></button></div>
+</div>
+</div>
+</div>
+<div class="row-offcanvas row-offcanvas-left">
+<div xmlns="http://www.w3.org/1999/xhtml" class="sidebar-offcanvas" id="sidebar">
+<nav class="offcanvas_nav" role="navigation">
+<div class="offcanvas_actuator" data-toggle="offcanvas" data-target="#sidebar" id="nav_toggle"><button type="button" class="btn"><span class="sr-only">Off-Canvas Navigation Menu Toggle
+                  Off-Canvas Navigation Menu Toggle</span><span class="icon-menu"></span></button><span class="offcanvas_actuator_label" id="translation_icon-menu" tabindex="-1" aria-hidden="true"></span></div><div class="nav_list_wrapper" id="nav_list_wrapper"><nav class="offcanvas_nav" role="navigation"><ul class="nav_breadcrumb" id="ul_left_nav_ancestors"><li itemscope="" itemtype="http://www.data-vocabulary.org/Breadcrumb" itemprop="breadcrumb"><a href="../../documentation-center.html?s_tid=CRUX_lftnav" itemprop="url"><span itemprop="title">Documentation Home</span></a></li>
+</ul><ul class="nav_breadcrumb" id="ul_left_nav_productgroups"><li itemscope="" itemtype="http://www.data-vocabulary.org/Breadcrumb" itemprop="breadcrumb"><a href="../../overview/robotics-and-autonomous-systems.html" itemprop="url"><span itemprop="title">Robotics and Autonomous Systems</span></a></li>
+<li itemscope="" itemtype="http://www.data-vocabulary.org/Breadcrumb" itemprop="breadcrumb"><a href="../../overview/automotive.html" itemprop="url"><span itemprop="title">Automotive</span></a></li>
+</ul>
+<ul class="nav_disambiguation"><li><a href="../index.html?s_tid=CRUX_lftnav">Automated Driving Toolbox</a>
+</li>
+<li itemscope="" itemtype="http://www.data-vocabulary.org/Breadcrumb" itemprop="breadcrumb"><a href="../scenario-simulation.html?s_tid=CRUX_lftnav" itemprop="url"><span itemprop="title">Scenario Simulation</span></a></li>
+<li itemscope="" itemtype="http://www.data-vocabulary.org/Breadcrumb" itemprop="breadcrumb"><a href="../unreal-engine-scenario-simulation.html?s_tid=CRUX_lftnav" itemprop="url"><span itemprop="title">Unreal Engine Scenario Simulation</span></a></li>
+</ul><ul class="nav_scrollspy nav">
+<li class="nav_scrollspy_function"><a href="#responsive_offcanvas">Install Support Package for Customizing Scenes</a></li>
+<li class="nav_scrollspy_title" id="SSPY810-section">On this page</li>
+<!--ADD_REFENTRY_TITLE_HERE 11--><li><a href="#mw_7092600d-7b1f-4b62-96e0-df0eb313fd99" class="intrnllnk">Verify Software and Hardware Requirements</a></li>
+<li><a href="#mw_11998698-3002-42bc-9df0-9ee12cb05e18" class="intrnllnk">Install Support Package</a></li>
+<li><a href="#mw_0d45adea-a5b6-4ee6-ac30-1809d30ba138" class="intrnllnk">Set Up Scene Customization Using Support Package</a><ul class="nav"><li><a href="#mw_72029cad-7cff-46d7-82a8-4807b42c5b2e" class="intrnllnk">Copy AutoVrtlEnv Project to Local Folder, and, MathWorksSimulation and MathWorksAutomotiveContent Plugins to Unreal Editor</a></li>
+<li><a href="#mw_7b088184-c0f7-4b3c-acc6-fb0b5b748fe4" class="intrnllnk">(Optional) Copy RRScene Project to Local Folder</a></li>
+<li><a href="#mw_90e7ae0b-5fd8-4a72-bee9-6b1d744c2a7d" class="intrnllnk">(Optional) Copy RoadRunnerMaterials Plugin to Unreal Editor</a></li>
+</ul></li>
+<li><a href="#d124e16954" class="intrnllnk">Related Topics</a></li>
+</ul>
+</nav>
+</div></nav>
+<script src="../../includes/product/scripts/offcanvas_v2.js"></script>
+</div>
+<!--END.CLASS sidebar-offcanvas--><div class="offcanvas_content_container">
+<div xmlns="http://www.w3.org/1999/xhtml" class="sticky_header_container"><div class="horizontal_nav"><div class="horizontal_nav_container"><div class="offcanvas_horizontal_nav"><div class="container-fluid"><div class="row"><div class="col-sm-12 hidden-xs"><nav class="navbar navbar-default" role="navigation" id="subnav"><div><ul class="nav navbar-nav crux_browse"><li id="crux_nav_documentation" class="crux_resource active"><a>Documentation</a></li>
+<li id="crux_nav_example" class="crux_resource"><a href="../examples.html?category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Examples</a></li>
+<li id="crux_nav_function" class="crux_resource"><a href="../referencelist.html?type=function&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Functions</a></li>
+<li id="crux_nav_block" class="crux_resource"><a href="../referencelist.html?type=block&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Blocks</a></li>
+<li id="crux_nav_app" class="crux_resource"><a href="../referencelist.html?type=app&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Apps</a></li>
+<li id="crux_nav_scene" class="crux_resource"><a href="../referencelist.html?type=scene&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Scenes</a></li>
+</ul>
+</div></nav>
+</div>
+<div class="visible-xs"><div class="container-fluid"><div class="row"><div class="col-xs-9"><div class="mobile_crux_nav_trigger"><div class="btn-group"><button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">Resources<span class="icon-arrow-down icon_16"></span></button><ul class="dropdown-menu"><li id="crux_nav_mobile_documentation" class="crux_resource active"><a>Documentation</a></li>
+<li id="crux_nav_mobile_example" class="crux_resource"><a href="../examples.html?category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Examples</a></li>
+<li id="crux_nav_mobile_function" class="crux_resource"><a href="../referencelist.html?type=function&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Functions</a></li>
+<li id="crux_nav_mobile_block" class="crux_resource"><a href="../referencelist.html?type=block&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Blocks</a></li>
+<li id="crux_nav_mobile_app" class="crux_resource"><a href="../referencelist.html?type=app&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Apps</a></li>
+<li id="crux_nav_mobile_scene" class="crux_resource"><a href="../referencelist.html?type=scene&amp;category=unreal-engine-scenario-simulation&amp;s_tid=CRUX_topnav">Scenes</a></li>
+</ul>
+</div>
+</div>
+</div>
+<div class="col-xs-3"><div class="translate_placeholder"></div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+</div>
+<div class="content_container" id="content_container" itemprop="content">
+<div class="container-fluid">
+<div class="row">
+<div class="col-xs-12">
+
+<div xmlns="http://www.w3.org/1999/xhtml" id="product_info_alert"></div>
+<section xmlns="http://www.w3.org/1999/xhtml" id="doc_center_content" lang="en" data-language="en"><div id="pgtype-topic">
+<section itemprop="content"><h2 class="title r2022b" itemprop="title content" id="mw_75c4b3ea-e08f-4af3-b6d6-e0a11e5fd6b4">安装定制场景支持包</h2>
+<div class="topic_progress_container pull-left remove_margin_0"><div class="topic_progress_desc"><a href="customize-3d-scenes-for-automated-driving.html"><strong>Step 1 of 4 in Customize Unreal Engine Scenes for Automated Driving</strong></a></div>
+<div class="topic_progress_indicator"><ul><li><a href="install-and-configure-support-package-for-customizing-scenes.html" class="active"></a></li>
+<li><a href="migrate-projects-developed-using-prior-support-packages.html"></a></li>
+<li><a href="customize-scenes-using-simulink-and-unreal-editor.html"></a></li>
+<li><a href="package-custom-scenes-into-executable.html"></a></li>
+</ul>
+</div>
+</div>
+<div class="clearfix"></div>
+<p>要在虚幻编辑器的安装中自定义场景并在Simulink®中模拟这些场景，您必须首先安装虚幻引擎4项目的自动驾驶工具箱界面。<br/></p>
+<div class="alert alert-info"><span class="alert_icon icon-alert-info-reverse"></span><p class="alert_heading"><b>注意</b></p>
+<p>这些安装说明适用于R2022b。如果您使用的是以前的版本，请参阅其他版本的文档。<br/></p>
+</div>
+<section itemprop="content"><h3 class="title" id="mw_7092600d-7b1f-4b62-96e0-df0eb313fd99">验证软件和硬件要求</h3>
+<p>在安装支持包之前，请确保您的环境满足虚幻引擎仿真环境要求和限制中描述的最低软件和硬件要求。<br/></p>
+</section>
+<section itemprop="content"><h3 class="title" id="mw_11998698-3002-42bc-9df0-9ee12cb05e18">安装支持包</h3>
+<p>要安装虚幻引擎®4项目支持包的自动驾驶工具箱™界面，请遵循以下步骤:<br/></p>
+<div class="orderedlist"><ol style="list-style: decimal;"><li><p>在MATLAB®Home选项卡的环境部分，选择Add-Ons &gt; Get Add-Ons。<br/></p>
+<div class="informalfigure"><div id="d124e16699" class="mediaobject"><p class="listimage"><img src="addons.png" alt="Add-Ons menu with Get Add-Ons selected" height="214" width="213"/></p>
+</div>
+</div><p></p></li>
+<li><p>在Add-On Explorer窗口中，搜索虚幻引擎4项目支持包的自动驾驶工具箱界面。点击Install。<br/></p>
+<div class="alert alert-info"><span class="alert_icon icon-alert-info-reverse"></span><p class="alert_heading"><b>注意</b></p>
+<p>您必须具有安装文件夹的写权限。</p>
+</div><p>
+</p></li>
+</ol>
+</div>
+</section>
+<section itemprop="content"><h3 class="title" id="mw_0d45adea-a5b6-4ee6-ac30-1809d30ba138">使用支持包设置场景定制</h3>
+<p>虚幻引擎4项目支持包的自动驾驶工具箱界面包括这些组件:<br/></p>
+<div class="itemizedlist"><ul><li><p><font face="monospace">AutoVrtlEnv文件夹 - 一个包含AutoVrtlEnv.Uproject文件及相应的支持文件的虚幻引擎项目文件夹。该项目包含预构建场景的可编辑版本，您可以从模拟3D场景配置块的场景名称参数中选择。</font><br/></p></li>
+<li><p><code class="literal">MathWorkSimulation </code><span style="font-family: monospace;">- </span>一个在Simulink和虚幻编辑器之间建立连接的插件。这是联合仿真所必需的。</p></li>
+<li><p><code class="literal">MathWorksAutomotiveContent </code><span style="font-family: monospace;">- </span>一个插件，包含汽车对象的元素，可以使用虚幻编辑器修改。这是联合仿真所必需的。</p></li>
+<li><p><code class="literal">RoadRunnerScenes </code><span style="font-family: monospace;">文件夹-</span> 包含虚幻引擎项目和使用RoadRunner场景编辑软件创建的场景的相应可执行文件的文件夹。此文件夹包含以下子文件夹:</p><div class="itemizedlist"><ul><li><p><code class="literal">RRScene</code> <span style="font-family: monospace;">-</span>  包含RRScene的虚幻引擎项目文件夹。Uproject文件及相应的支持文件。这个项目包含一个可编辑的场景版本，在公路车道跟随RoadRunner场景示例中使用。</p></li>
+<li><p><code class="literal">WindowsPackage</code> <span style="font-family: monospace;">-</span>  包含可执行的RRScene.exe和支持文件的文件夹。使用这个可执行文件来共同模拟在公路车道跟随RoadRunner场景示例中解释的Simulink模型。</p></li>
+</ul>
+</div><div class="itemizedlist"><ul><li><p><code class="literal">RoadRunnerMaterials</code> <span style="font-family: monospace;">-</span> 一个插件，它包含了roadrunner场景中对象的特性。</p></li>
+</ul>
+</div></li>
+</ul>
+</div>
+<p>要设置场景定制，你必须将AutoVrtlEnv项目和MathWorksSimulation插件文件夹复制到本地机器上。要自定义RoadRunner场景中使用的公路车道跟随RoadRunner场景示例，你还必须复制RRScene项目到你的本地机器上，下载RoadRunner materials插件并复制到你的本地项目中。<br/></p>
+<p>安装和设置支持包之后，就可以开始定制场景了。如果您想使用使用虚幻引擎4项目支持包的先前版本的自动驾驶工具箱界面开发的项目，您必须迁移该项目，使其与当前支持的虚幻编辑器版本兼容。请参阅使用先前支持包开发的迁移项目。否则，请参见使用Simulink和虚幻编辑器自定义场景。<br/></p>
+<section itemprop="content"><h4 class="title" id="mw_72029cad-7cff-46d7-82a8-4807b42c5b2e">复制AutoVrtlEnv项目到本地文件夹，MathWorksSimulation和MathWorksAutomotiveContent插件到虚幻编辑器<br/></h4>
+<p>要将所有支持包组件复制到本地机器上的一个文件夹中，并配置您的环境，以便您可以自定义场景，请使用copyExampleSim3dProject函数。例如，以下代码将文件复制到C:\project。<br/></p>
+<div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre>sim3d.utils.copyExampleSim3dProject(<span style="color:#A020F0">"C:\project"</span>);</pre>
+</div>
+</div>
+</div>
+<p></p>
+</section>
+<section itemprop="content"><h4 class="title" id="mw_7b088184-c0f7-4b3c-acc6-fb0b5b748fe4">(可选)拷贝“RRScene工程”到本地文件夹<br/></h4>
+<p>要在RRScene项目文件夹中自定义场景，请将项目复制到本地机器上。<br/></p>
+<div class="orderedlist"><ol style="list-style: decimal;"><li><p>指定包含项目的支持包文件夹的路径。还要指定复制项目的本地文件夹目标。这段代码使用了前几节中的支持包路径和本地文件夹路径。</p><div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre>rrProjectSupportPackageFolder = fullfile( <span style="color:#0000FF">...</span>
+    matlabshared.supportpkg.getSupportPackageRoot, <span style="color:#0000FF">...</span>
+    <span style="color:#A020F0">"toolbox"</span>,<span style="color:#A020F0">"shared"</span>,<span style="color:#A020F0">"sim3dprojects"</span>,<span style="color:#A020F0">"driving"</span>, <span style="color:#0000FF">...</span>
+    <span style="color:#A020F0">"RoadRunnerScenes"</span>,<span style="color:#A020F0">"RRScene"</span>);
+rrProjectLocalFolder = fullfile(localFolder,<span style="color:#A020F0">"RRScene"</span>);</pre>
+</div>
+</div>
+</div></li>
+<li><p>将RRScene项目从支持包文件夹复制到本地目标文件夹。<br/></p><div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre><span style="color:#0000FF">if</span> ~exist(rrProjectLocalFolder,<span style="color:#A020F0">"dir"</span>)
+    copyfile(rrProjectSupportPackageFolder,rrProjectLocalFolder);
+<span style="color:#0000FF">end</span></pre>
+</div>
+</div>
+</div></li>
+</ol>
+</div>
+<p>RRScene.uproject文件及其所有支持文件现在位于指定的本地文件夹中名为RRScene的文件夹中。例如:C:\Local\RRScene。<br/></p>
+</section>
+<section itemprop="content"><h4 class="title" id="mw_90e7ae0b-5fd8-4a72-bee9-6b1d744c2a7d">(可选)复制RoadRunnerMaterials插件到虚幻编辑器<br/></h4>
+<p><font color="#212121" face="Roboto, sans-serif"><span style="font-size: 13px;">当在RRScene项目文件夹中定制场景时，你还必须将RoadRunnerMaterials插件复制到你的插件项目文件夹中。</span></font><br/></p>
+<div class="orderedlist"><ol style="list-style: decimal;"><li><p>下载包含最新RoadRunner插件的ZIP文件。参见下载插件(RoadRunner)。将ZIP文件的内容解压缩到本地机器。解压后的文件夹名为“RoadRunner Plugins x.x.x”，其中x.x.x为插件的版本号。<br/></p></li>
+<li><p>指定RoadRunnerMaterials插件的路径。这个插件位于解压文件夹的虚幻/插件文件夹中。更新此代码以匹配下载插件的位置和插件版本号。<br/></p><div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre>rrMaterialsPluginFolder = fullfile(<span style="color:#A020F0">"C:"</span>,<span style="color:#A020F0">"Local"</span>,<span style="color:#A020F0">"RoadRunner Plugins 1.0.3"</span>, <span style="color:#0000FF">...</span>
+    <span style="color:#A020F0">"Unreal"</span>,<span style="color:#A020F0">"Plugins"</span>,<span style="color:#A020F0">"RoadRunnerMaterials"</span>);</pre>
+</div>
+</div>
+</div></li>
+<li><p>在您的本地RRScene项目中，创建一个Plugins文件夹，用于复制插件。这段代码使用上一节中指定的本地RRScene项目的路径。<br/></p><div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre>rrProjectPluginFolder = fullfile(rrProjectLocalFolder,<span style="color:#A020F0">"Plugins"</span>,<span style="color:#A020F0">"RoadRunnerMaterials"</span>);</pre>
+</div>
+</div>
+</div></li>
+<li><p>将RoadRunnerMaterials插件复制到本地项目的Plugins文件夹中。<br/></p><div class="code_responsive"><div class="programlisting"><div class="codeinput"><pre>copyStatus = copyfile(rrMaterialsPluginFolder,rrProjectPluginFolder);
+<span style="color:#0000FF">if</span> copyStatus
+    disp(<span style="color:#A020F0">"Successfully copied RoadRunnerMaterials plugin to RRScene project plugins folder."</span>)
+<span style="color:#0000FF">else</span>
+    disp(<span style="color:#A020F0">"Unable to copy RoadRunnerMaterials plugin to RRScene project plugins folder."</span>)
+<span style="color:#0000FF">end</span></pre>
+</div>
+</div>
+</div></li>
+</ol>
+</div>
+<p>安装和设置支持包之后，就可以开始定制场景了。如果您想使用使用虚幻引擎4项目支持包的先前版本的自动驾驶工具箱界面开发的项目，您必须迁移该项目，使其与当前支持的虚幻编辑器版本兼容。请参阅使用先前支持包开发的迁移项目。否则，请参见使用Simulink和虚幻编辑器自定义场景。<br/></p>
+</section>
+</section>
+<h2 id="d124e16954">Related Topics</h2>
+<ul><li><a href="3d-simulation-for-automated-driving.html" class="a">Unreal Engine Simulation for Automated Driving</a></li>
+<li><a href="3d-visualization-engine-requirements.html" class="a">Unreal Engine Simulation Environment Requirements and Limitations</a></li>
+</ul>
+</section>
+    </div>
+<div class="topic_progress_container"><div class="topic_progress_desc"><a href="customize-3d-scenes-for-automated-driving.html"><strong>Customize Unreal Engine Scenes for Automated Driving</strong></a></div>
+<div class="topic_progress_indicator"><ul><li><a href="install-and-configure-support-package-for-customizing-scenes.html" class="active"></a></li>
+<li><a href="migrate-projects-developed-using-prior-support-packages.html"></a></li>
+<li><a href="customize-scenes-using-simulink-and-unreal-editor.html"></a></li>
+<li><a href="package-custom-scenes-into-executable.html"></a></li>
+</ul>
+</div>
+<div class="topic_progress_nav"><a href="migrate-projects-developed-using-prior-support-packages.html">Next <span class="icon-arrow-open-right"></span></a></div>
+</div>
+<div class="clearfix"></div>
+<div align="center" class="feedbackblock" id="mw_docsurvey"><script src="https://www.mathworks.com/help/docsurvey/docfeedback.js"></script>
+<script>loadSurveyHidden();</script>
+<link rel="stylesheet" href="https://www.mathworks.com/help/docsurvey/release/index-css.css" type="text/css"/>
+<script src="https://www.mathworks.com/help/docsurvey/release/bundle.index.js"></script>
+
+<script>initDocSurvey();</script>
+</div>
+</section>
+
+
+</div>
+</div>
+</div>
+</div>
+<!--close_0960--><footer xmlns="http://www.w3.org/1999/xhtml" id="footer" class="bs-footer">
+<div class="container-fluid">
+<div class="footer">
+<div class="row">
+<div class="col-xs-12">
+<p class="copyright">© 1994-2022 The MathWorks, Inc.</p>
+<ul class="footernav"><li class="footernav_help"><a href="matlab:web(matlab.internal.licenseAgreement)">Terms of Use</a></li>
+<li class="footernav_patents"><a href="matlab:web([matlabroot '/patents.txt'])">Patents</a></li>
+<li class="footernav_trademarks"><a href="matlab:web([matlabroot '/trademarks.txt'])">Trademarks</a></li>
+<li class="footernav_piracy"><a href="matlab:web([docroot '/acknowledgments.html'])">Acknowledgments</a></li>
+</ul>
+</div>
+</div>
+</div>
+</div>
+</footer>
+</div>
+<!--close row-offcanvas--></div>
+<!--close_0970-->
+</body>
+</html>


### PR DESCRIPTION
Simulink仿真时所使用的车辆资产确实是ue插件MathWorksAutomotiveContent里的，而MathWorksSimulation起链接作用，MathWorksAutomotiveContent提供汽车元素。并且，都应该在ue的\Plugins\MathWorks目录下。